### PR TITLE
fix: custom compare for bus name in rules

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-01-15T21:20:48Z"
+  build_date: "2024-01-25T15:56:52Z"
   build_hash: 3753ca3f6610172e9e652d6e5e62e0a05f2e639c
   go_version: go1.21.4
-  version: v0.28.0-11-g3753ca3-dirty
+  version: v0.28.0-11-g3753ca3
 api_directory_checksum: 2f1b4315ca163085aac81e9834ec3cc8e670ceaa
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 6863520425c03341a6de215a02f6a281ee5a75e5
+  file_checksum: a1d77e96cb09841795e7eba5be091ff23196d494
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -167,6 +167,8 @@ resources:
         references:
           resource: EventBus
           path: Spec.Name
+        compare:
+          is_ignored: true
       scheduleExpression:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -167,6 +167,8 @@ resources:
         references:
           resource: EventBus
           path: Spec.Name
+        compare:
+          is_ignored: true
       scheduleExpression:
         compare:
           is_ignored: true

--- a/pkg/resource/rule/delta.go
+++ b/pkg/resource/rule/delta.go
@@ -51,13 +51,6 @@ func newResourceDelta(
 			delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.EventBusName, b.ko.Spec.EventBusName) {
-		delta.Add("Spec.EventBusName", a.ko.Spec.EventBusName, b.ko.Spec.EventBusName)
-	} else if a.ko.Spec.EventBusName != nil && b.ko.Spec.EventBusName != nil {
-		if *a.ko.Spec.EventBusName != *b.ko.Spec.EventBusName {
-			delta.Add("Spec.EventBusName", a.ko.Spec.EventBusName, b.ko.Spec.EventBusName)
-		}
-	}
 	if !reflect.DeepEqual(a.ko.Spec.EventBusRef, b.ko.Spec.EventBusRef) {
 		delta.Add("Spec.EventBusRef", a.ko.Spec.EventBusRef, b.ko.Spec.EventBusRef)
 	}

--- a/pkg/resource/rule/hooks_test.go
+++ b/pkg/resource/rule/hooks_test.go
@@ -214,3 +214,99 @@ func Test_equalScheduleExpression(t *testing.T) {
 		})
 	}
 }
+
+func Test_equalEventBusName(t *testing.T) {
+	var (
+		defaultEventBusName = "default"
+		emptyString         = ""
+		customEventBusName  = "custom"
+	)
+	type args struct {
+		desiredExpression *string
+		latestExpression  *string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "equal: desired nil, latest default",
+			args: args{
+				desiredExpression: nil,
+				latestExpression:  &defaultEventBusName,
+			},
+			want: true,
+		}, {
+			name: "equal: desired default, latest nil",
+			args: args{
+				desiredExpression: nil,
+				latestExpression:  &defaultEventBusName,
+			},
+			want: true,
+		}, {
+			name: "equal: desired empty string, latest nil",
+			args: args{
+				desiredExpression: &emptyString,
+				latestExpression:  nil,
+			},
+			want: true,
+		}, {
+			name: "equal: desired is default, latest empty string",
+			args: args{
+				desiredExpression: &defaultEventBusName,
+				latestExpression:  &emptyString,
+			},
+			want: true,
+		}, {
+			name: "equal: both nil",
+			args: args{
+				desiredExpression: nil,
+				latestExpression:  nil,
+			},
+			want: true,
+		}, {
+			name: "equal: both same default value",
+			args: args{
+				desiredExpression: &defaultEventBusName,
+				latestExpression:  &defaultEventBusName,
+			},
+			want: true,
+		}, {
+			name: "equal: both same custom value",
+			args: args{
+				desiredExpression: &customEventBusName,
+				latestExpression:  &customEventBusName,
+			},
+			want: true,
+		}, {
+			name: "not equal: desired nil, latest custom value",
+			args: args{
+				desiredExpression: nil,
+				latestExpression:  &customEventBusName,
+			},
+			want: false,
+		}, {
+			name: "not equal: desired default, latest custom value",
+			args: args{
+				desiredExpression: &defaultEventBusName,
+				latestExpression:  &customEventBusName,
+			},
+			want: false,
+		}, {
+			name: "not equal: desired custom value, latest default",
+			args: args{
+				desiredExpression: &defaultEventBusName,
+				latestExpression:  &customEventBusName,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalEventBusName(tt.args.desiredExpression, tt.args.latestExpression); got != tt.want {
+				t.Errorf("equalEventBusName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue #, if available: Closes: #1989

Description of changes:

Fixes a comparison issue where `""`, `nil` and `"default"` for `eventBusName` in a `Rule` were not considered equal.

Note that this change does not fix the immutability issue, i.e., changing `eventBusName` from `"default"` to `nil` in a spec will trigger the reconciliation logic, then `sdkFind` won't find the object because it has a different name and treat it as a `create` path instead of `update`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
