### PR TITLE
Fix generator.yaml: remove EventBusName field with no SDK shape

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-01-07T18:52:47Z"
-  build_hash: e743d683160cf0f58a4864e052cdcb0927335ca7
-  go_version: go1.25.5
-  version: v0.57.0
+  build_date: "2026-02-19T00:11:30Z"
+  build_hash: af61bc1478baf08196fb6e2c81590518a754e45e
+  go_version: go1.25.6
+  version: v0.57.0-9-gaf61bc1
 api_directory_checksum: c3290e1eaad0e7d2a2ec91d9ede20854d76bbd84
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: fcb83c945a932db152141e629664bb748c2620ce
+  file_checksum: a1b9bd2bc17becdc92fe85187ecd06716f0d88a6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -138,8 +138,6 @@ resources:
       Name:
         is_immutable: true
         is_required: true
-      EventBusName:
-        is_immutable: true
       Tags:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -138,8 +138,6 @@ resources:
       Name:
         is_immutable: true
         is_required: true
-      EventBusName:
-        is_immutable: true
       Tags:
         compare:
           is_ignored: true


### PR DESCRIPTION
The EventBus.EventBusName field had no matching SDK shape member and lacked from/custom_field/type annotations. Removed it to pass code-generator validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
