### PR TITLE
Mark EventPattern as is_document in Archive and Rule

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:45:42Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-06-19T03:06:29Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
+  go_version: go1.26.0
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: c3290e1eaad0e7d2a2ec91d9ede20854d76bbd84
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: a1b9bd2bc17becdc92fe85187ecd06716f0d88a6
+  file_checksum: 242dff9f32e83dfdd527b13aa233cb0d595f0572
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -23,6 +23,8 @@ operations:
 resources:
   Archive:
     fields:
+      EventPattern:
+        is_document: true
       Name:
         is_immutable: true
         is_required: true
@@ -168,6 +170,8 @@ resources:
       # making this terminal would leak bus resources in AWS and K8s control planes
   Rule:
     fields:
+      EventPattern:
+        is_document: true
       EventBusName:
         is_immutable: true # seems to not affect EventBusRef
         references:

--- a/generator.yaml
+++ b/generator.yaml
@@ -23,6 +23,8 @@ operations:
 resources:
   Archive:
     fields:
+      EventPattern:
+        is_document: true
       Name:
         is_immutable: true
         is_required: true
@@ -168,6 +170,8 @@ resources:
       # making this terminal would leak bus resources in AWS and K8s control planes
   Rule:
     fields:
+      EventPattern:
+        is_document: true
       EventBusName:
         is_immutable: true # seems to not affect EventBusRef
         references:

--- a/pkg/resource/archive/delta.go
+++ b/pkg/resource/archive/delta.go
@@ -52,7 +52,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.EventPattern, b.ko.Spec.EventPattern) {
 		delta.Add("Spec.EventPattern", a.ko.Spec.EventPattern, b.ko.Spec.EventPattern)
 	} else if a.ko.Spec.EventPattern != nil && b.ko.Spec.EventPattern != nil {
-		if *a.ko.Spec.EventPattern != *b.ko.Spec.EventPattern {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.EventPattern, *b.ko.Spec.EventPattern); err != nil || !equal {
 			delta.Add("Spec.EventPattern", a.ko.Spec.EventPattern, b.ko.Spec.EventPattern)
 		}
 	}

--- a/pkg/resource/rule/delta.go
+++ b/pkg/resource/rule/delta.go
@@ -56,7 +56,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.EventPattern, b.ko.Spec.EventPattern) {
 		delta.Add("Spec.EventPattern", a.ko.Spec.EventPattern, b.ko.Spec.EventPattern)
 	} else if a.ko.Spec.EventPattern != nil && b.ko.Spec.EventPattern != nil {
-		if *a.ko.Spec.EventPattern != *b.ko.Spec.EventPattern {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.EventPattern, *b.ko.Spec.EventPattern); err != nil || !equal {
 			delta.Add("Spec.EventPattern", a.ko.Spec.EventPattern, b.ko.Spec.EventPattern)
 		}
 	}

--- a/test/e2e/resources/archive.yaml
+++ b/test/e2e/resources/archive.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   name: $ARCHIVE_NAME
   eventSourceARN: $EVENT_SOURCE_ARN
+  eventPattern: |
+    {"source":["aws.ec2"]}

--- a/test/e2e/tests/test_archive.py
+++ b/test/e2e/tests/test_archive.py
@@ -131,6 +131,16 @@ class TestArchive:
         archive = eventbridge_validator.get_archive(archive_name)
         assert archive["Description"] == new_description
 
+        # Update eventPattern to verify is_document comparison works
+        updates = {
+            "spec": {
+                "eventPattern": '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"]}',
+            }
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted


### PR DESCRIPTION
## Summary

Adds is_document: true annotation to EventPattern field in both Archive and Rule resources in generator.yaml.

## Problem

The EventPattern field in both Archive and Rule resources accepts a JSON event pattern document. Without the is_document annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_document: true to Archive.EventPattern in generator.yaml
- Added is_document: true to Rule.EventPattern in generator.yaml
- Regenerated controller code - delta.go now uses DocumentEqual for semantic comparison
- Added eventPattern to existing archive.yaml test fixture (rule.yaml already has it)

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e tests exercise the eventPattern field

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.